### PR TITLE
Correções relacionadas ao EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Execute em seu terminal:
 docker compose up -d
 ```
 
+No Linux, na primeira execução, é possível que seja necessário criar um diretório para os logs do banco. Faça isso com o comando:
+
+```bash
+mkdir logs
+chmod 777 logs
+```
+
 Para remover o ambiente, execute:
 
 ```bash

--- a/config/2_config.sh
+++ b/config/2_config.sh
@@ -2,10 +2,10 @@
 
 file="/opt/sql/__create__.txt";
 while read t; do
-  if [[ -z "${t%?}" || ${t:0:1} == '#' ]]; then
+  if [[ -z "$t" || ${t:0:1} == '#' ]]; then
     continue;
   fi
-  table="/opt/sql/${t%?}.sql";
+  table="/opt/sql/$t.sql";
   echo -e "Trying to create the table $table\n";
   psql -U postgres -d andifes -f $table;
 done < "$file";

--- a/sql/__create__.txt
+++ b/sql/__create__.txt
@@ -1,5 +1,4 @@
 # Arquivo contendo a ordem de criação das tabelas.
-
 # META
 __tipos
 


### PR DESCRIPTION
O script de inicialização levava em conta o caractere de fim de linha do Windows e isso ocasionava problemas ao tentar executar o container no Linux.

É para estar funcionando agora.